### PR TITLE
Correction du nouveau lien vers le SGB

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ Ici vous trouverez des liens rapides vers les documents et éléments importants
 <!-- Projet -->
 [projet-exigences]: README-exigences-client.md
 [projet-squelette]: https://github.com/profcfuhrmanets/log210-jeu-de-des-node-express-ts/tree/master/docs/Squelette.md
-[projet-sgb]: https://github.com/profcfuhrman/log210-systeme-gestion-bordereau-node-express-ts
+[projet-sgb]: https://github.com/fuhrmanator/log210-systeme-gestion-bordereau-node-express-ts
 
 <!-- Gabarits -->
 [gabarit-rapport]: rapports/RAPPORT-iteration-i.md


### PR DESCRIPTION
Le fixe #84 ne semble pas avoir un lien fonctionnel. Le projet existe sur fuhrmanator et non profcfuhrmanets.